### PR TITLE
sheetify: return stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,9 @@ const opts = {
   basedir: __dirname
 }
 
-sheetify(path.join(__dirname, 'index.css'), opts, function (err, css) {
-  if (err) throw err
-  console.log(css)
-})
+sheetify(path.join(__dirname, 'index.css'), opts)
+  .on('error', err => console.log(err))
+  .pipe(process.stdout)
 ```
 
 ## As a browserify transform

--- a/package.json
+++ b/package.json
@@ -20,10 +20,12 @@
     "astw-babylon": "^1.0.0",
     "babylon": "^5.8.23",
     "cliclopts": "^1.1.1",
+    "concat-stream": "^1.5.1",
     "css-prefix": "0.0.2",
     "domify": "^1.4.0",
     "escodegen": "^1.7.0",
     "findup": "^0.1.5",
+    "from2-string": "^1.1.0",
     "insert-css": "^0.2.0",
     "is-require": "0.0.1",
     "map-limit": "0.0.1",
@@ -32,6 +34,8 @@
     "postcss": "^5.0.10",
     "postcss-class-prefix": "^0.3.0",
     "postcss-prefix": "^1.0.0",
+    "pump": "^1.0.1",
+    "readable-stream": "^2.0.4",
     "resolve": "^1.1.6",
     "run-waterfall": "^1.1.3",
     "sleuth": "^0.1.1",
@@ -48,7 +52,6 @@
     "standard": "^5.2.1",
     "tape": "^4.2.0",
     "through2": "^2.0.0",
-    "wrap-selectors": "^0.1.0",
-    "xtend": "^4.0.1"
+    "wrap-selectors": "^0.1.0"
   }
 }


### PR DESCRIPTION
This might be controversial because it changes the behavior in browser / in client. Perhaps we should aim to make the in-browser require be a separate file instead. Not sure. Anyway: this allows us to stream.

## Todo (wip)
- return a `.bundle()` method
- return a `.use()` method that can be used before `bundle`