### PR TITLE
Allow specifying transforms through package.json

### DIFF
--- a/transform.js
+++ b/transform.js
@@ -74,6 +74,9 @@ function transform (filename, options) {
           : {}
 
         opts.basedir = opts.basedir || path.dirname(filename)
+        opts.use = []
+          .concat(opts.use || [])
+          .concat(options.use || [])
 
         sheetify(sourceFile, opts, function (err, style, uuid) {
           if (err) return next(err)


### PR DESCRIPTION
This change makes it possible to specify sheetify transforms
across your package through browserify transform arguments, e.g.

    {
      "browserify": {
        "transform": [
          ["sheetify", { "use": ["sheetify-cssnext"] }]
        ]
      }
    }

Thanks! :)