### PR TITLE
stream: fix error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ function transform (filename, src, options, done) {
     }
 
     const name = plugin[0]
-    const opts = plugin[1]
+    const opts = plugin[1] || {}
 
     nodeResolve(name, {
       basedir: opts.basedir || options.basedir

--- a/stream.js
+++ b/stream.js
@@ -21,7 +21,7 @@ function sheetifyStream (path, opts) {
   // force async to prevent weird race conditions
   process.nextTick(function () {
     sheetify(path, opts, function (err, css) {
-      if (err) return rs.emit('error', err)
+      if (err) return pts.emit('error', err)
 
       const ln = css.length
       var i = 0


### PR DESCRIPTION
## changes
- errors weren't emitted properly by the stream
- plugins always required an options object, whereas this shouldn't be the case; this is now correctly handled

Merging once tests pass 👀