### PR TITLE
default opts to empty object

### DIFF
--- a/transform.js
+++ b/transform.js
@@ -27,6 +27,7 @@ function transform (filename, opts) {
   const nodes = []
   var mname = null
 
+  opts = opts || {}
   opts.basedir = opts.basedir || process.cwd()
   opts = xtend(opts)
 


### PR DESCRIPTION
To avoid error when opts is not defined.