### PR TITLE
emit errors instead of throw

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,14 @@ Options:
   -u, --use    Consume a sheetify plugin
 ```
 
+## FAQ
+### Help, why isn't my inline CSS being transformed?
+Well, that might be because you're running `babelify` before running
+`sheetify`. `sheetify` looks for template strings in your code and then
+transforms them as inline stylesheets. If these are caught and transformed to
+ES5 strings by `babelify` then `sheetify` ends up sad. So try running
+`sheetify` before `babelify` and you should be good, we hope.
+
 ## Installation
 ```sh
 $ npm install sheetify

--- a/lib/css-resolve.js
+++ b/lib/css-resolve.js
@@ -1,0 +1,29 @@
+const resolve = require('resolve')
+const path = require('path')
+
+module.exports = cssResolve
+
+// find a file in CSS with either a {style} field
+// or main with `.css` in it
+// (str, str) -> str
+function cssResolve (pkgname, basedir) {
+  try {
+    const res = resolve.sync(pkgname, {
+      basedir: pkgname,
+      packageFilter: packageFilter
+    })
+
+    if (path.extname(res) !== '.css') {
+      throw new Error('path ' + res + ' is not a CSS file')
+    }
+
+    return res
+  } catch (e) {
+    return
+  }
+
+  function packageFilter (pkg, path) {
+    if (pkg.style) pkg.main = pkg.style
+    return pkg
+  }
+}

--- a/test/import.js
+++ b/test/import.js
@@ -5,11 +5,12 @@ const path = require('path')
 const fs = require('fs')
 
 const sheetify = require(path.join(__dirname, '../transform'))
-const expath = require.resolve('css-type-base/index.css')
-const expected = fs.readFileSync(expath, 'utf8').trim()
 
 test('import', function (t) {
   t.plan(1)
+
+  const expath = require.resolve('css-type-base/index.css')
+  const expected = fs.readFileSync(expath, 'utf8').trim()
 
   const ws = concat(function (buf) {
     const res = String(buf).trim()
@@ -25,6 +26,33 @@ test('import', function (t) {
 
   const r = b.bundle()
   r.resume()
+  r.on('end', function () {
+    ws.end()
+  })
+})
+
+test('broken import should emit an error', function (t) {
+  t.plan(1)
+
+  const inpath = path.join(__dirname, 'import/broken.js')
+
+  const ws = concat(function (buf) {
+    const res = String(buf).trim()
+    console.log(res)
+  })
+
+  const bOpts = { browserField: false }
+  const b = browserify(inpath, bOpts)
+  b.transform(sheetify, {
+    basedir: path.join(__dirname, 'plugins'),
+    o: ws
+  })
+
+  const r = b.bundle()
+  r.resume()
+  r.on('error', function (e) {
+    t.ok(/cannot be imported/.test(e), 'emits an error')
+  })
   r.on('end', function () {
     ws.end()
   })

--- a/test/import/broken.js
+++ b/test/import/broken.js
@@ -1,0 +1,3 @@
+const sf = require('sheetify')
+
+sf('./not-a-file.css')


### PR DESCRIPTION
This patch makes it so that events are emitted instead of thrown, making `sheetify` handle runtime errors more correctly:
- moves `css-resolve` function to separate file (`transform.js` is still huge 😕)
- added a more descriptive error message in case neither a module, path or inline stylesheet work
- added tests for said case
- added a FAQ notice about possible conflicts between `babelify` and `sheetify`

resolves #49 and #48 (partially)

Thanks! :sparkles: