### PR TITLE
Bugfixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,8 +50,9 @@ function parseCss (src, filename, prefix, options, next) {
   // one at the time
   // (str, str, obj, fn) -> null
   function applyTransforms (filename, src, options, done) {
-    var use = options.use || []
-    use = Array.isArray(use) ? use.slice() : [ use ]
+    options.u = options.u || []
+    options.use = options.use || []
+    var use = [].concat(options.use).concat(options.u)
 
     mapLimit(use, 1, iterate, function (err) {
       if (err) return done(err)

--- a/transform.js
+++ b/transform.js
@@ -22,14 +22,13 @@ module.exports = transform
 //    with CSS injection or extract CSS to callback
 // 4. flush transform
 // obj -> (str, opts) -> str
-function transform (filename, opts) {
+function transform (filename, options) {
   const bufs = []
   const nodes = []
   var mname = null
 
-  opts = opts || {}
+  const opts = xtend(options || {})
   opts.basedir = opts.basedir || process.cwd()
-  opts = xtend(opts)
 
   // argv parsing
   if (opts.o) opts.out = opts.o
@@ -105,6 +104,8 @@ function transform (filename, opts) {
   // transform an AST node
   // obj -> null
   function walk (node) {
+    opts.global = false
+
     // transform require calls
     if (node.type === 'CallExpression' &&
     node.callee && node.callee.name === 'require' &&
@@ -140,7 +141,9 @@ function transform (filename, opts) {
       // - don't prefix by default if module import
       // - check if local file
       try {
-        var resolvePath = cssResolve(node.arguments[0].value, { basedir: opts.basedir })
+        var resolvePath = cssResolve(node.arguments[0].value, {
+          basedir: opts.basedir
+        })
       } catch (err) {
         if (err.message.substring(0, 18) !== 'Cannot find module') {
           throw err


### PR DESCRIPTION
- `-u` wasn't being caught by transforms - whoops
- `{global: 'true'}` would leak between parsed nodes

did this in a hurry; presentation tomorrow! :sparkles: